### PR TITLE
fix: animate.css 几率性的抖动

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import 'animate.css'
+import './style.css'
 import ElementUI from 'element-ui';
 import 'element-ui/lib/theme-chalk/index.css';
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,5 @@
+html, body {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}


### PR DESCRIPTION
`animate.css` 几率性的会造成抖动, 原因是撑高了父容器, `<html><body>`